### PR TITLE
GitHub Action - Upload GitHub Release to redaxo.org automatically

### DIFF
--- a/.github/workflows/publish-to-redaxo-org.yml
+++ b/.github/workflows/publish-to-redaxo-org.yml
@@ -1,0 +1,18 @@
+# Instructions: https://github.com/FriendsOfREDAXO/installer-action/
+
+name: Publish to REDAXO.org
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  redaxo_publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: FriendsOfREDAXO/installer-action@v1
+      with:
+        myredaxo-username: ${{ secrets.MYREDAXO_USERNAME }}
+        myredaxo-api-key: ${{ secrets.MYREDAXO_API_KEY }}
+        description: ${{ github.event.release.body }}


### PR DESCRIPTION
Falls gewünscht: Siehe https://github.com/FriendsOfREDAXO/installer-action

Todo: Credentials in deinem GitHub-Account dafür hinterlegen, gemäß Anleitung s.o.